### PR TITLE
Fix typo in NoteCreatedOnLabel

### DIFF
--- a/Vulcanova/Vulcanova/Resources/Strings.resx
+++ b/Vulcanova/Vulcanova/Resources/Strings.resx
@@ -286,7 +286,7 @@
         <value>Created by</value>
     </data>
     <data name="NoteCreatedOnLabel" xml:space="preserve">
-        <value>Created by</value>
+        <value>Created on</value>
     </data>
     <data name="NoteCommentLabel" xml:space="preserve">
         <value>Comment</value>


### PR DESCRIPTION
![image](https://github.com/Vulcanova/Vulcanova/assets/105926196/91c28dec-f2ff-4d5b-b311-8425d6e51158)
